### PR TITLE
feat: add a virtual extension with flavor ID to generated assets

### DIFF
--- a/cmd/image-service/cmd/service.go
+++ b/cmd/image-service/cmd/service.go
@@ -68,7 +68,7 @@ func RunService(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to parse external installer repository: %w", err)
 	}
 
-	frontendHTTP, err := frontendhttp.NewFrontend(logger, configService, assetBuilder, frontendOptions)
+	frontendHTTP, err := frontendhttp.NewFrontend(logger, configService, assetBuilder, artifactsManager, frontendOptions)
 	if err != nil {
 		return fmt.Errorf("failed to initialize HTTP frontend: %w", err)
 	}

--- a/internal/artifacts/flavor.go
+++ b/internal/artifacts/flavor.go
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package artifacts
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/talos/pkg/machinery/extensions"
+	"gopkg.in/yaml.v3"
+
+	"github.com/siderolabs/image-service/pkg/flavor"
+)
+
+// GetFlavorExtension returns a path to the tarball with "virtual" extension matching a specified flavor.
+func (m *Manager) GetFlavorExtension(ctx context.Context, flavor *flavor.Flavor) (string, error) {
+	flavorID, err := flavor.ID()
+	if err != nil {
+		return "", err
+	}
+
+	extensionPath := filepath.Join(m.flavorsPath, flavorID+".tar")
+
+	resultCh := m.flavorsSingleFlight.DoChan(flavorID, func() (any, error) {
+		return nil, m.buildFlavorExtension(flavorID, extensionPath)
+	})
+
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return "", result.Err
+		}
+
+		return extensionPath, nil
+	}
+}
+
+// flavorExtension builds a "virtual" extension matching a specified flavor.
+func flavorExtension(flavorID string) (io.Reader, error) {
+	manifest := extensions.Manifest{
+		Version: "v1alpha1",
+		Metadata: extensions.Metadata{
+			Name:        "flavor",
+			Version:     flavorID,
+			Author:      "Image Service",
+			Description: "Virtual extension which specifies the flavor of the image built with Image Service.",
+			Compatibility: extensions.Compatibility{
+				Talos: extensions.Constraint{
+					Version: ">= 1.0.0",
+				},
+			},
+		},
+	}
+
+	manifestBytes, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	var buf bytes.Buffer
+
+	tw := tar.NewWriter(&buf)
+
+	if err = tw.WriteHeader(&tar.Header{
+		Name:     "manifest.yaml",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(manifestBytes)),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to write manifest header: %w", err)
+	}
+
+	if _, err = tw.Write(manifestBytes); err != nil {
+		return nil, fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	for _, path := range []string{
+		"rootfs/",
+		"rootfs/usr/",
+		"rootfs/usr/local/",
+		"rootfs/usr/local/share/",
+		"rootfs/usr/local/share/flavor/",
+	} {
+		if err = tw.WriteHeader(&tar.Header{
+			Name:     path,
+			Typeflag: tar.TypeDir,
+			Mode:     0o755,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to write rootfs header: %w", err)
+		}
+	}
+
+	if err = tw.WriteHeader(&tar.Header{
+		Name:     filepath.Join("rootfs/usr/local/share/flavor", flavorID), // empty file
+		Typeflag: tar.TypeReg,
+		Mode:     0o755,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to write rootfs header: %w", err)
+	}
+
+	if err = tw.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close tar writer: %w", err)
+	}
+
+	return &buf, nil
+}
+
+// buildFlavorExtension builds a flavor extension tarball.
+func (m *Manager) buildFlavorExtension(flavorID, extensionPath string) error {
+	tarball, err := flavorExtension(flavorID)
+	if err != nil {
+		return fmt.Errorf("failed to build flavor layer: %w", err)
+	}
+
+	f, err := os.Create(extensionPath + ".tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create extension tarball: %w", err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	_, err = io.Copy(f, tarball)
+	if err != nil {
+		return fmt.Errorf("failed to write extension tarball: %w", err)
+	}
+
+	if err = os.Rename(extensionPath+".tmp", extensionPath); err != nil {
+		return fmt.Errorf("failed to rename extension tarball: %w", err)
+	}
+
+	return f.Close()
+}

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/siderolabs/image-service/internal/artifacts"
 	"github.com/siderolabs/image-service/internal/asset"
 	flvr "github.com/siderolabs/image-service/internal/flavor"
 	"github.com/siderolabs/image-service/internal/flavor/storage"
@@ -28,14 +29,15 @@ import (
 
 // Frontend is the HTTP frontend.
 type Frontend struct {
-	router        *httprouter.Router
-	flavorService *flvr.Service
-	assetBuilder  *asset.Builder
-	logger        *zap.Logger
-	puller        *remote.Puller
-	pusher        *remote.Pusher
-	sf            singleflight.Group
-	options       Options
+	router           *httprouter.Router
+	flavorService    *flvr.Service
+	assetBuilder     *asset.Builder
+	artifactsManager *artifacts.Manager
+	logger           *zap.Logger
+	puller           *remote.Puller
+	pusher           *remote.Pusher
+	sf               singleflight.Group
+	options          Options
 }
 
 // Options configures the HTTP frontend.
@@ -49,13 +51,14 @@ type Options struct {
 }
 
 // NewFrontend creates a new HTTP frontend.
-func NewFrontend(logger *zap.Logger, flavorService *flvr.Service, assetBuilder *asset.Builder, opts Options) (*Frontend, error) {
+func NewFrontend(logger *zap.Logger, flavorService *flvr.Service, assetBuilder *asset.Builder, artifactsManager *artifacts.Manager, opts Options) (*Frontend, error) {
 	frontend := &Frontend{
-		router:        httprouter.New(),
-		flavorService: flavorService,
-		assetBuilder:  assetBuilder,
-		logger:        logger.With(zap.String("frontend", "http")),
-		options:       opts,
+		router:           httprouter.New(),
+		flavorService:    flavorService,
+		assetBuilder:     assetBuilder,
+		artifactsManager: artifactsManager,
+		logger:           logger.With(zap.String("frontend", "http")),
+		options:          opts,
 	}
 
 	var err error

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -46,7 +46,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		return fmt.Errorf("error parsing profile from path: %w", err)
 	}
 
-	prof, err = profile.EnhanceFromFlavor(prof, flavor, versionTag)
+	prof, err = profile.EnhanceFromFlavor(ctx, prof, flavor, f.artifactsManager, versionTag)
 	if err != nil {
 		return fmt.Errorf("error enhancing profile from flavor: %w", err)
 	}

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -53,7 +53,7 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 		return fmt.Errorf("error parsing profile from path: %w", err)
 	}
 
-	prof, err = profile.EnhanceFromFlavor(prof, flavor, versionTag)
+	prof, err = profile.EnhanceFromFlavor(ctx, prof, flavor, f.artifactsManager, versionTag)
 	if err != nil {
 		return fmt.Errorf("error enhancing profile from flavor: %w", err)
 	}

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -198,7 +198,7 @@ func (f *Frontend) buildInstallImage(ctx context.Context, img requestedImage, fl
 	for _, arch := range []artifacts.Arch{artifacts.ArchAmd64, artifacts.ArchArm64} {
 		prof := profile.InstallerProfile(img.SecureBoot(), arch)
 
-		prof, err := profile.EnhanceFromFlavor(prof, flavor, versionTag)
+		prof, err := profile.EnhanceFromFlavor(ctx, prof, flavor, f.artifactsManager, versionTag)
 		if err != nil {
 			return fmt.Errorf("error enhancing profile from flavor: %w", err)
 		}


### PR DESCRIPTION
This appends a "virtual" (built on the fly) extension which contains flavor ID to all boot assets of Talos.

This allows to easily identify which flavor of Talos which asset was built with.

E.g.:

```
$ talosctl -n 172.20.0.2 get extensions -i
NODE   NAMESPACE   TYPE              ID   VERSION   NAME     VERSION
       runtime     ExtensionStatus   0    1         flavor   376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
```

```yaml
node:
metadata:
    namespace: runtime
    type: ExtensionStatuses.runtime.talos.dev
    id: 0
    version: 1
    owner: runtime.ExtensionStatusController
    phase: running
    created: 2023-09-07T14:06:03Z
    updated: 2023-09-07T14:06:03Z
spec:
    image: 0.sqsh
    metadata:
        name: flavor
        version: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
        author: Image Service
        description: Virtual extension which specifies the flavor of the image built with Image Service.
        compatibility:
            talos:
                version: '>= 1.0.0'
```

And (as an empty file):

```
$ talosctl -n 172.20.0.2 ls /usr/local/share/flavor/
NODE         NAME
172.20.0.2   .
172.20.0.2   376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
```