### PR TITLE
feat: implement support for system extensions

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -101,7 +101,7 @@ spec:
       - name: TEST_FLAGS
         defaultValue: ""
     script:
-      - "@$(MAKE) image-image-service PUSH=true"
+      - "@$(MAKE) image-image-service PUSH=true GO_BUILDFLAGS=-race CGO_ENABLED=1"
       - docker pull $(REGISTRY)/$(USERNAME)/image-service:$(TAG)
       - docker run --rm --net=host --privileged -v /dev:/dev -v $(PWD)/$(ARTIFACTS)/integration.test:/bin/integration.test:ro --entrypoint /bin/integration.test $(REGISTRY)/$(USERNAME)/image-service:$(TAG) -test.v $(TEST_FLAGS) -test.run $(RUN_TESTS)
   drone:
@@ -110,3 +110,7 @@ spec:
     environment:
       REGISTRY: registry.dev.talos-systems.io
       TEST_FLAGS: "-test.flavor-service-repository=registry.dev.talos-systems.io/image-service/flavor -test.installer-external-repository=registry.dev.talos-systems.io/siderolabs -test.installer-internal-repository=registry.dev.talos-systems.io/siderolabs"
+---
+kind: auto.CI
+spec:
+    provider: drone

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-08-31T14:21:15Z by kres latest.
+# Generated on 2023-09-12T19:22:18Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -127,7 +127,10 @@ COPY --from=embed-generate / /
 WORKDIR /src/cmd/image-service
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=amd64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /image-service-linux-amd64
+ARG VERSION_PKG="internal/version"
+ARG SHA
+ARG TAG
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=amd64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=image-service -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /image-service-linux-amd64
 
 # builds image-service-linux-arm64
 FROM base AS image-service-linux-arm64-build
@@ -136,7 +139,10 @@ COPY --from=embed-generate / /
 WORKDIR /src/cmd/image-service
 ARG GO_BUILDFLAGS
 ARG GO_LDFLAGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /image-service-linux-arm64
+ARG VERSION_PKG="internal/version"
+ARG SHA
+ARG TAG
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=image-service -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /image-service-linux-arm64
 
 FROM scratch AS image-service-linux-amd64
 COPY --from=image-service-linux-amd64-build /image-service-linux-amd64 /image-service-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-09-05T15:30:31Z by kres latest.
+# Generated on 2023-09-12T19:22:18Z by kres latest.
 
 # common variables
 
@@ -202,7 +202,7 @@ integration.test:
 
 .PHONY: integration
 integration: integration.test
-	@$(MAKE) image-image-service PUSH=true
+	@$(MAKE) image-image-service PUSH=true GO_BUILDFLAGS=-race CGO_ENABLED=1
 	docker pull $(REGISTRY)/$(USERNAME)/image-service:$(TAG)
 	docker run --rm --net=host --privileged -v /dev:/dev -v $(PWD)/$(ARTIFACTS)/integration.test:/bin/integration.test:ro --entrypoint /bin/integration.test $(REGISTRY)/$(USERNAME)/image-service:$(TAG) -test.v $(TEST_FLAGS) -test.run $(RUN_TESTS)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Official Image Service is available at [https://imager.talos.dev](https://imager
 
 ## HTTP Frontend API
 
-### `POST /flavor`
+### `POST /flavors`
 
 Create a new image flavor.
 
@@ -30,6 +30,10 @@ The request body is a YAML (JSON) encoded flavor description:
 customization:
     extraKernelArgs: # optional
         - vga=791
+    systemExtensions: # optional
+      officialExtensions: # optional
+        - siderolabs/gvisor
+        - siderolabs/amd-ucode
 ```
 
 Output is a JSON-encoded flavor ID:
@@ -72,6 +76,29 @@ Supported image paths:
   * `aws-<arch>.raw.xz` (e.g. `aws-amd64.raw.xz`) - raw disk image for AWS platform, that can be imported as an AMI
   * `gcp-<arch>.raw.tar.gz` (e.g. `gcp-amd64.raw.tar.gz`) - raw disk image for GCP platform, that can be imported as a GCE image
   * ... other support image types
+
+### `GET /versions`
+
+Returns a list of Talos versions available for image generation.
+
+```json
+["v1.5.0","v1.5.1", "v1.5.2"]
+```
+
+### `GET /version/:version/extensions/official`
+
+Returns a list of official system extensions available for the specified Talos version.
+
+```json
+[
+  {
+    "name": "siderolabs/amd-ucode",
+    "ref": "ghcr.io/siderolabs/amd-ucode:20230804",
+    "digest": "sha256:761a5290a4bae9ceca11468d2ba8ca7b0f94e6e3a107ede2349ae26520682832",
+  },
+
+]
+```
 
 ## PXE Frontend API
 
@@ -125,5 +152,5 @@ The image platform (architecture) will be determined by the architecture of the 
 Run integration tests in local mode, with registry mirrors:
 
 ```bash
-make integration TEST_FLAGS="-test.image-prefix=127.0.0.1:5004/siderolabs/ -test.flavor-service-repository=127.0.0.1:5005/image-service/flavor -test.installer-external-repository=127.0.0.1:5005/test -test.installer-internal-repository=127.0.0.1:5005/test" REGISTRY=127.0.0.1:5005
+make integration TEST_FLAGS="-test.image-registry=127.0.0.1:5004 -test.flavor-service-repository=127.0.0.1:5005/image-service/flavor -test.installer-external-repository=127.0.0.1:5005/test -test.installer-internal-repository=127.0.0.1:5005/test" REGISTRY=127.0.0.1:5005
 ```

--- a/cmd/image-service/cmd/options.go
+++ b/cmd/image-service/cmd/options.go
@@ -4,6 +4,8 @@
 
 package cmd
 
+import "time"
+
 // Options configures image service.
 type Options struct { //nolint:govet
 	// Listen address for the HTTP frontend.
@@ -11,8 +13,8 @@ type Options struct { //nolint:govet
 
 	// Asset builder options: minimum supported Talos version.
 	MinTalosVersion string
-	// Image prefix for the `imager`.
-	ImagePrefix string
+	// Image registry for source images: imager, extensions, etc..
+	ImageRegistry string
 
 	// Options to verify container signatures for imager, extensions, etc.
 	ContainerSignatureSubjectRegExp string
@@ -33,14 +35,17 @@ type Options struct { //nolint:govet
 	// - external one for the redirects
 	InstallerInternalRepository string
 	InstallerExternalRepository string
+
+	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.
+	TalosVersionRecheckInterval time.Duration
 }
 
 // DefaultOptions are the default options.
 var DefaultOptions = Options{
 	HTTPListenAddr: ":8080",
 
-	MinTalosVersion: "1.4.0",
-	ImagePrefix:     "ghcr.io/siderolabs/",
+	MinTalosVersion: "1.4.0-alpha.0",
+	ImageRegistry:   "ghcr.io",
 
 	ContainerSignatureSubjectRegExp: `@siderolabs\.com$`,
 	ContainerSignatureIssuer:        "https://accounts.google.com",
@@ -53,4 +58,6 @@ var DefaultOptions = Options{
 
 	InstallerInternalRepository: "ghcr.io/siderolabs",
 	InstallerExternalRepository: "ghcr.io/siderolabs",
+
+	TalosVersionRecheckInterval: 15 * time.Minute,
 }

--- a/cmd/image-service/cmd/service.go
+++ b/cmd/image-service/cmd/service.go
@@ -130,8 +130,8 @@ func buildArtifactsManager(ctx context.Context, logger *zap.Logger, opts Options
 	}
 
 	artifactsManager, err := artifacts.NewManager(logger, artifacts.Options{
-		MinVersion:  minVersion,
-		ImagePrefix: opts.ImagePrefix,
+		MinVersion:    minVersion,
+		ImageRegistry: opts.ImageRegistry,
 		ImageVerifyOptions: cosign.CheckOpts{
 			Identities: []cosign.Identity{
 				{
@@ -144,6 +144,8 @@ func buildArtifactsManager(ctx context.Context, logger *zap.Logger, opts Options
 			RekorPubKeys:      rekorPubKeys,
 			CTLogPubKeys:      ctLogPubKeys,
 		},
+		TalosVersionRecheckInterval: opts.TalosVersionRecheckInterval,
+		RemoteOptions:               remoteOptions(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize artifacts manager: %w", err)

--- a/cmd/image-service/flags.go
+++ b/cmd/image-service/flags.go
@@ -17,7 +17,7 @@ func initFlags() cmd.Options {
 	flag.StringVar(&opts.HTTPListenAddr, "http-port", cmd.DefaultOptions.HTTPListenAddr, "HTTP listen address")
 
 	flag.StringVar(&opts.MinTalosVersion, "min-talos-version", cmd.DefaultOptions.MinTalosVersion, "minimum Talos version")
-	flag.StringVar(&opts.ImagePrefix, "image-prefix", cmd.DefaultOptions.ImagePrefix, "image prefix")
+	flag.StringVar(&opts.ImageRegistry, "image-registry", cmd.DefaultOptions.ImageRegistry, "image registry for imager, extensions, etc.")
 
 	flag.StringVar(&opts.ContainerSignatureSubjectRegExp, "container-signature-subject-regexp", cmd.DefaultOptions.ContainerSignatureSubjectRegExp, "container signature subject regexp")
 	flag.StringVar(&opts.ContainerSignatureIssuer, "container-signature-issuer", cmd.DefaultOptions.ContainerSignatureIssuer, "container signature issuer")
@@ -30,6 +30,8 @@ func initFlags() cmd.Options {
 
 	flag.StringVar(&opts.InstallerExternalRepository, "installer-external-repository", cmd.DefaultOptions.InstallerExternalRepository, "image repository for the installer (external)")
 	flag.StringVar(&opts.InstallerInternalRepository, "installer-internal-repository", cmd.DefaultOptions.InstallerInternalRepository, "image repository for the installer (internal)")
+
+	flag.DurationVar(&opts.TalosVersionRecheckInterval, "talos-versions-recheck-interval", cmd.DefaultOptions.TalosVersionRecheckInterval, "interval to recheck Talos versions")
 
 	flag.Parse()
 

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -9,19 +9,24 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
 // Options are the options for the artifacts manager.
-type Options struct {
-	// ImagePrefix is the prefix for the image name.
+type Options struct { //nolint:govet
+	// ImageRegistry is the registry which stores imager, extensions, etc..
 	//
-	// For official images, this is "ghcr.io/siderolabs/"
-	ImagePrefix string
+	// For official images, this is "ghcr.io".
+	ImageRegistry string
 	// MinVersion is the minimum version of Talos to use.
 	MinVersion semver.Version
 	// ImageVerifyOptions are the options for verifying the image signature.
 	ImageVerifyOptions cosign.CheckOpts
+	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.
+	TalosVersionRecheckInterval time.Duration
+	// RemoteOptions is the list of remote options for the puller.
+	RemoteOptions []remote.Option
 }
 
 // Kind is the artifact kind.
@@ -37,3 +42,10 @@ const (
 
 // FetchTimeout controls overall timeout for fetching artifacts for a release.
 const FetchTimeout = 20 * time.Minute
+
+// Various images.
+const (
+	InstallerImage         = "siderolabs/installer"
+	ImagerImage            = "siderolabs/imager"
+	ExtensionManifestImage = "siderolabs/extensions"
+)

--- a/internal/artifacts/flavor.go
+++ b/internal/artifacts/flavor.go
@@ -28,7 +28,7 @@ func (m *Manager) GetFlavorExtension(ctx context.Context, flavor *flavor.Flavor)
 
 	extensionPath := filepath.Join(m.flavorsPath, flavorID+".tar")
 
-	resultCh := m.flavorsSingleFlight.DoChan(flavorID, func() (any, error) {
+	resultCh := m.sf.DoChan(flavorID, func() (any, error) {
 		return nil, m.buildFlavorExtension(flavorID, extensionPath)
 	})
 

--- a/internal/artifacts/manager.go
+++ b/internal/artifacts/manager.go
@@ -10,23 +10,33 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 )
 
 // Manager supports loading, caching and serving Talos release artifacts.
 type Manager struct { //nolint:govet
-	options     Options
-	storagePath string
-	flavorsPath string
-	logger      *zap.Logger
+	options       Options
+	storagePath   string
+	flavorsPath   string
+	logger        *zap.Logger
+	imageRegistry name.Registry
+	pullers       map[Arch]*remote.Puller
 
-	flavorsSingleFlight singleflight.Group
+	sf singleflight.Group
 
-	fetcherMu sync.Mutex
-	fetchers  map[string]*fetcher
+	officialExtensionsMu sync.Mutex
+	officialExtensions   map[string][]ExtensionRef
+
+	talosVersionsMu        sync.Mutex
+	talosVersions          []semver.Version
+	talosVersionsTimestamp time.Time
 }
 
 // NewManager creates a new artifacts manager.
@@ -42,12 +52,37 @@ func NewManager(logger *zap.Logger, options Options) (*Manager, error) {
 		return nil, fmt.Errorf("failed to create flavors directory: %w", err)
 	}
 
+	imageRegistry, err := name.NewRegistry(options.ImageRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image registry: %w", err)
+	}
+
+	pullers := make(map[Arch]*remote.Puller, 2)
+
+	for _, arch := range []Arch{ArchAmd64, ArchArm64} {
+		pullers[arch], err = remote.NewPuller(
+			append(
+				[]remote.Option{
+					remote.WithPlatform(v1.Platform{
+						Architecture: string(arch),
+						OS:           "linux",
+					}),
+				},
+				options.RemoteOptions...,
+			)...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create puller: %w", err)
+		}
+	}
+
 	return &Manager{
-		options:     options,
-		storagePath: tmpDir,
-		flavorsPath: flavorsPath,
-		logger:      logger,
-		fetchers:    map[string]*fetcher{},
+		options:       options,
+		storagePath:   tmpDir,
+		flavorsPath:   flavorsPath,
+		logger:        logger,
+		imageRegistry: imageRegistry,
+		pullers:       pullers,
 	}, nil
 }
 
@@ -68,16 +103,22 @@ func (m *Manager) Get(ctx context.Context, versionString string, arch Arch, kind
 	}
 
 	tag := "v" + version.String()
-	errCh := m.fetch(tag) //nolint:contextcheck
 
-	// wait for the fetch to finish
-	select {
-	case err = <-errCh:
-		if err != nil {
-			return "", err
+	// check if already extracted
+	if _, err = os.Stat(filepath.Join(m.storagePath, tag)); err != nil {
+		resultCh := m.sf.DoChan(tag, func() (any, error) {
+			return nil, m.fetchImager(tag)
+		})
+
+		// wait for the fetch to finish
+		select {
+		case result := <-resultCh:
+			if result.Err != nil {
+				return "", err
+			}
+		case <-ctx.Done():
+			return "", ctx.Err()
 		}
-	case <-ctx.Done():
-		return "", ctx.Err()
 	}
 
 	// build the path
@@ -93,35 +134,97 @@ func (m *Manager) Get(ctx context.Context, versionString string, arch Arch, kind
 
 // GetInstallerImageRef returns the installer image reference for the given version.
 func (m *Manager) GetInstallerImageRef(versionString string) string {
-	return m.options.ImagePrefix + "installer:v" + versionString
+	return m.imageRegistry.Repo(InstallerImage).Tag("v" + versionString).String()
 }
 
-// fetch a version of Talos artifacts.
-func (m *Manager) fetch(tag string) <-chan error {
-	m.fetcherMu.Lock()
-	defer m.fetcherMu.Unlock()
+// GetTalosVersions returns a list of Talos versions available.
+func (m *Manager) GetTalosVersions(ctx context.Context) ([]semver.Version, error) {
+	m.talosVersionsMu.Lock()
+	versions, timestamp := m.talosVersions, m.talosVersionsTimestamp
+	m.talosVersionsMu.Unlock()
 
-	fetcher, ok := m.fetchers[tag]
-	if !ok {
-		fetcher = newFetcher()
-		m.fetchers[tag] = fetcher
-
-		fetcher.Fetch(m.logger, tag, m.options, m.storagePath)
-
-		// cleanup fetcher if it fails
-		cleanupCh := fetcher.Subscribe()
-
-		go func() {
-			if err := <-cleanupCh; err != nil {
-				m.fetcherMu.Lock()
-				defer m.fetcherMu.Unlock()
-
-				if m.fetchers[tag] == fetcher {
-					delete(m.fetchers, tag)
-				}
-			}
-		}()
+	if time.Since(timestamp) < m.options.TalosVersionRecheckInterval {
+		return versions, nil
 	}
 
-	return fetcher.Subscribe()
+	resultCh := m.sf.DoChan("talos-versions", m.fetchTalosVersions)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+	}
+
+	m.talosVersionsMu.Lock()
+	versions = m.talosVersions
+	m.talosVersionsMu.Unlock()
+
+	return versions, nil
+}
+
+// GetOfficialExtensions returns a list of Talos extensions per Talos version available.
+func (m *Manager) GetOfficialExtensions(ctx context.Context, versionString string) ([]ExtensionRef, error) {
+	version, err := semver.ParseTolerant(versionString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version: %w", err)
+	}
+
+	if version.LT(m.options.MinVersion) {
+		return nil, fmt.Errorf("version %s is not supported, minimum is %s", version, m.options.MinVersion)
+	}
+
+	tag := "v" + version.String()
+
+	m.officialExtensionsMu.Lock()
+	extensions, ok := m.officialExtensions[tag]
+	m.officialExtensionsMu.Unlock()
+
+	if ok {
+		return extensions, nil
+	}
+
+	resultCh := m.sf.DoChan("extensions-"+tag, func() (any, error) {
+		return nil, m.fetchOfficialExtensions(tag)
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+	}
+
+	m.officialExtensionsMu.Lock()
+	extensions = m.officialExtensions[tag]
+	m.officialExtensionsMu.Unlock()
+
+	return extensions, nil
+}
+
+// GetExtensionImage pulls and exports an extension image.
+func (m *Manager) GetExtensionImage(ctx context.Context, arch Arch, ref ExtensionRef) (string, error) {
+	tarballPath := filepath.Join(m.storagePath, string(arch)+"-"+ref.Digest+".tar")
+
+	// check if already fetched
+	if _, err := os.Stat(tarballPath); err != nil {
+		resultCh := m.sf.DoChan(tarballPath, func() (any, error) {
+			return nil, m.fetchExtensionImage(arch, ref, tarballPath)
+		})
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case result := <-resultCh:
+			if result.Err != nil {
+				return "", result.Err
+			}
+		}
+	}
+
+	return tarballPath, nil
 }

--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -1,0 +1,161 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package artifacts
+
+import (
+	"archive/tar"
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/go-containerregistry/pkg/name"
+	"go.uber.org/zap"
+)
+
+func (m *Manager) fetchTalosVersions() (any, error) {
+	m.logger.Info("fetching available Talos versions")
+
+	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+	defer cancel()
+
+	repository := m.imageRegistry.Repo(ImagerImage)
+
+	candidates, err := m.pullers[ArchAmd64].List(ctx, repository)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Talos versions: %w", err)
+	}
+
+	var versions []semver.Version //nolint:prealloc
+
+	for _, candidate := range candidates {
+		version, err := semver.ParseTolerant(candidate)
+		if err != nil {
+			continue // ignore invalid versions
+		}
+
+		if version.LT(m.options.MinVersion) {
+			continue // ignore versions below minimum
+		}
+
+		// filter out intermediate versions
+		if len(version.Pre) > 0 {
+			if len(version.Pre) != 2 {
+				continue
+			}
+
+			if !(version.Pre[0].VersionStr == "alpha" || version.Pre[0].VersionStr == "beta") {
+				continue
+			}
+
+			if !version.Pre[1].IsNumeric() {
+				continue
+			}
+		}
+
+		versions = append(versions, version)
+	}
+
+	slices.SortFunc(versions, func(a, b semver.Version) int {
+		return a.Compare(b)
+	})
+
+	m.talosVersionsMu.Lock()
+	m.talosVersions, m.talosVersionsTimestamp = versions, time.Now()
+	m.talosVersionsMu.Unlock()
+
+	return nil, nil //nolint:nilnil
+}
+
+// ExtensionRef is a ref to the extension for some Talos version.
+type ExtensionRef struct {
+	TaggedReference name.Tag
+	Digest          string
+}
+
+func (m *Manager) fetchOfficialExtensions(tag string) error {
+	var extensions []ExtensionRef
+
+	if err := m.fetchImageByTag(ExtensionManifestImage, tag, ArchAmd64, func(logger *zap.Logger, r io.Reader) error {
+		var extractErr error
+
+		extensions, extractErr = extractExtensionList(r)
+
+		if extractErr == nil {
+			m.logger.Info("extracted the image digests", zap.Int("count", len(extensions)))
+		}
+
+		return extractErr
+	}); err != nil {
+		return err
+	}
+
+	m.officialExtensionsMu.Lock()
+
+	if m.officialExtensions == nil {
+		m.officialExtensions = make(map[string][]ExtensionRef)
+	}
+
+	m.officialExtensions[tag] = extensions
+
+	m.officialExtensionsMu.Unlock()
+
+	return nil
+}
+
+func extractExtensionList(r io.Reader) ([]ExtensionRef, error) {
+	var extensions []ExtensionRef
+
+	tr := tar.NewReader(r)
+
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, fmt.Errorf("error reading tar header: %w", err)
+		}
+
+		if hdr.Name == "image-digests" {
+			scanner := bufio.NewScanner(tr)
+
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+
+				tagged, digest, ok := strings.Cut(line, "@")
+				if !ok {
+					continue
+				}
+
+				taggedRef, err := name.NewTag(tagged)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse tagged reference %s: %w", tagged, err)
+				}
+
+				extensions = append(extensions, ExtensionRef{
+					TaggedReference: taggedRef,
+					Digest:          digest,
+				})
+			}
+
+			if scanner.Err() != nil {
+				return nil, fmt.Errorf("error reading image-digests: %w", scanner.Err())
+			}
+		}
+	}
+
+	if extensions != nil {
+		return extensions, nil
+	}
+
+	return nil, errors.New("failed to find image-digests file")
+}

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -91,7 +91,11 @@ func NewFrontend(logger *zap.Logger, flavorService *flvr.Service, assetBuilder *
 	frontend.router.HEAD("/v2/:image/:flavor/manifests/:tag", frontend.wrapper(frontend.handleManifest))
 
 	// flavor
-	frontend.router.POST("/flavor", frontend.wrapper(frontend.handleFlavorCreate))
+	frontend.router.POST("/flavors", frontend.wrapper(frontend.handleFlavorCreate))
+
+	// meta
+	frontend.router.GET("/versions", frontend.wrapper(frontend.handleVersions))
+	frontend.router.GET("/version/:version/extensions/official", frontend.wrapper(frontend.handleOfficialExtensions))
 
 	return frontend, nil
 }

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -68,6 +68,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		w.Header().Set("Content-Type", mime.TypeByExtension(ext))
 	}
 
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, path))
 	w.WriteHeader(http.StatusOK)
 
 	if r.Method == http.MethodHead {

--- a/internal/frontend/http/meta.go
+++ b/internal/frontend/http/meta.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xslices"
+
+	"github.com/siderolabs/image-service/internal/artifacts"
+)
+
+// handleVersions handles list of Talos versions available.
+func (f *Frontend) handleVersions(ctx context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+	versions, err := f.artifactsManager.GetTalosVersions(ctx)
+	if err != nil {
+		return err
+	}
+
+	return json.NewEncoder(w).Encode(
+		xslices.Map(versions, func(v semver.Version) string {
+			return "v" + v.String()
+		}),
+	)
+}
+
+// handleOfficialExtensions handles list of available official extensions per Talos version.
+func (f *Frontend) handleOfficialExtensions(ctx context.Context, w http.ResponseWriter, _ *http.Request, p httprouter.Params) error {
+	versionTag := p.ByName("version")
+	if !strings.HasPrefix(versionTag, "v") {
+		versionTag = "v" + versionTag
+	}
+
+	version, err := semver.Parse(versionTag[1:])
+	if err != nil {
+		return fmt.Errorf("error parsing version: %w", err)
+	}
+
+	extensions, err := f.artifactsManager.GetOfficialExtensions(ctx, version.String())
+	if err != nil {
+		return err
+	}
+
+	type extensionInfo struct {
+		Name   string `json:"name"`
+		Ref    string `json:"ref"`
+		Digest string `json:"digest"`
+	}
+
+	return json.NewEncoder(w).Encode(
+		xslices.Map(extensions, func(e artifacts.ExtensionRef) extensionInfo {
+			return extensionInfo{
+				Name:   e.TaggedReference.RepositoryStr(),
+				Ref:    e.TaggedReference.String(),
+				Digest: e.Digest,
+			}
+		}),
+	)
+}

--- a/internal/integration/download_test.go
+++ b/internal/integration/download_test.go
@@ -103,53 +103,75 @@ func testDownloadFrontend(ctx context.Context, t *testing.T, baseURL string) {
 		t.Run(talosVersion, func(t *testing.T) {
 			t.Parallel()
 
-			t.Run("iso", func(t *testing.T) {
+			t.Run("empty flavor", func(t *testing.T) {
 				t.Parallel()
 
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-amd64.iso", "application/x-iso9660-image", 82724864)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-arm64.iso", "application/x-iso9660-image", 122007552)
+				t.Run("iso", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-amd64.iso", "application/x-iso9660-image", 82724864)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-arm64.iso", "application/x-iso9660-image", 122007552)
+				})
+
+				t.Run("kernel", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "kernel-amd64", "application/vnd.microsoft.portable-executable", 16708992)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "kernel-arm64", "application/vnd.microsoft.portable-executable", 69356032)
+				})
+
+				t.Run("initramfs", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "initramfs-amd64.xz", "application/x-xz", 57.5*MiB)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "initramfs-arm64.xz", "application/x-xz", 42.5*MiB)
+				})
+
+				t.Run("installer image", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "installer-amd64.tar", "application/x-tar", 167482880)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "installer-arm64.tar", "application/x-tar", 163630080)
+				})
+
+				t.Run("metal image", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-amd64.raw.xz", "application/x-xz", 78472708)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-arm64.raw.xz", "application/x-xz", 66625420)
+				})
+
+				t.Run("aws image", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "aws-amd64.raw.xz", "application/x-xz", 78472708)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "aws-arm64.raw.xz", "application/x-xz", 66625420)
+				})
+
+				t.Run("gcp image", func(t *testing.T) {
+					t.Parallel()
+
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "gcp-amd64.raw.tar.gz", "application/gzip", 78472708)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "gcp-arm64.raw.tar.gz", "application/gzip", 70625420)
+				})
 			})
 
-			t.Run("kernel", func(t *testing.T) {
+			t.Run("extensions flavor", func(t *testing.T) {
 				t.Parallel()
 
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "kernel-amd64", "application/vnd.microsoft.portable-executable", 16708992)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "kernel-arm64", "application/vnd.microsoft.portable-executable", 69356032)
-			})
+				t.Run("iso", func(t *testing.T) {
+					t.Parallel()
 
-			t.Run("initramfs", func(t *testing.T) {
-				t.Parallel()
+					downloadAssetAndMatch(ctx, t, baseURL, systemExtensionsFlavorID, talosVersion, "metal-amd64.iso", "application/x-iso9660-image", 112222208)
+					downloadAssetAndMatch(ctx, t, baseURL, systemExtensionsFlavorID, talosVersion, "metal-arm64.iso", "application/x-iso9660-image", 150120448)
+				})
 
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "initramfs-amd64.xz", "application/x-xz", 57.5*MiB)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "initramfs-arm64.xz", "application/x-xz", 42.5*MiB)
-			})
+				t.Run("metal image", func(t *testing.T) {
+					t.Parallel()
 
-			t.Run("installer image", func(t *testing.T) {
-				t.Parallel()
-
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "installer-amd64.tar", "application/x-tar", 167482880)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "installer-arm64.tar", "application/x-tar", 163630080)
-			})
-
-			t.Run("metal image", func(t *testing.T) {
-				t.Parallel()
-
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-amd64.raw.xz", "application/x-xz", 78472708)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-arm64.raw.xz", "application/x-xz", 66625420)
-			})
-
-			t.Run("aws image", func(t *testing.T) {
-				t.Parallel()
-
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "aws-amd64.raw.xz", "application/x-xz", 78472708)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "aws-arm64.raw.xz", "application/x-xz", 66625420)
-			})
-
-			t.Run("gcp image", func(t *testing.T) {
-				t.Parallel()
-
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "gcp-amd64.raw.tar.gz", "application/gzip", 78472708)
-				downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "gcp-arm64.raw.tar.gz", "application/gzip", 70625420)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-amd64.raw.xz", "application/x-xz", 78472708)
+					downloadAssetAndMatch(ctx, t, baseURL, emptyFlavorID, talosVersion, "metal-arm64.raw.xz", "application/x-xz", 66625420)
+				})
 			})
 		})
 	}

--- a/internal/integration/flavor_test.go
+++ b/internal/integration/flavor_test.go
@@ -24,14 +24,15 @@ import (
 
 // well known flavor IDs, they will be created with the test run
 const (
-	emptyFlavorID     = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
-	extraArgsFlavorID = "e0fb1129bbbdfb5d002e94af4cdce712a8370e850950a33a242d4c3f178c532d"
+	emptyFlavorID            = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+	extraArgsFlavorID        = "e0fb1129bbbdfb5d002e94af4cdce712a8370e850950a33a242d4c3f178c532d"
+	systemExtensionsFlavorID = "51ff3e49313773332729a5c04e57af0dbe2e6d3f65ff638e6d4c3a05065fefff"
 )
 
 func createFlavor(ctx context.Context, t *testing.T, baseURL string, marshalled []byte) *http.Response {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/flavor", bytes.NewReader(marshalled))
+	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/flavors", bytes.NewReader(marshalled))
 	require.NoError(t, err)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -91,6 +92,22 @@ func testFlavor(ctx context.Context, t *testing.T, baseURL string) {
 		))
 	})
 
+	t.Run("system extensions", func(t *testing.T) {
+		assert.Equal(t, systemExtensionsFlavorID, createFlavorGetID(ctx, t, baseURL,
+			flavor.Flavor{
+				Customization: flavor.Customization{
+					SystemExtensions: flavor.SystemExtensions{
+						OfficialExtensions: []string{
+							"siderolabs/amd-ucode",
+							"siderolabs/gvisor",
+							"siderolabs/gasket-driver",
+						},
+					},
+				},
+			},
+		))
+	})
+
 	t.Run("empty once again", func(t *testing.T) {
 		assert.Equal(t, emptyFlavorID, createFlavorGetID(ctx, t, baseURL, flavor.Flavor{}))
 	})
@@ -107,6 +124,11 @@ func testFlavor(ctx context.Context, t *testing.T, baseURL string) {
 			flavor.Flavor{
 				Customization: flavor.Customization{
 					ExtraKernelArgs: []string{randomKernelArg},
+					SystemExtensions: flavor.SystemExtensions{
+						OfficialExtensions: []string{
+							"siderolabs/amd-ucode",
+						},
+					},
 				},
 			},
 		), 64)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -30,7 +30,7 @@ func setupService(t *testing.T) (context.Context, string) {
 
 	options := cmd.DefaultOptions
 	options.HTTPListenAddr = findListenAddr(t)
-	options.ImagePrefix = imagePrefixFlag
+	options.ImageRegistry = imageRegistryFlag
 	options.ExternalURL = "http://" + options.HTTPListenAddr + "/"
 	options.FlavorServiceRepository = flavorServiceRepositoryFlag
 	options.InstallerExternalRepository = installerExternalRepository
@@ -100,17 +100,23 @@ func TestIntegration(t *testing.T) {
 
 		testRegistryFrontend(ctx, t, listenAddr)
 	})
+
+	t.Run("TestMetaFrontend", func(t *testing.T) {
+		t.Parallel()
+
+		testMetaFrontend(ctx, t, baseURL)
+	})
 }
 
 var (
-	imagePrefixFlag             string
+	imageRegistryFlag           string
 	flavorServiceRepositoryFlag string
 	installerExternalRepository string
 	installerInternalRepository string
 )
 
 func init() {
-	flag.StringVar(&imagePrefixFlag, "test.image-prefix", cmd.DefaultOptions.ImagePrefix, "image prefix")
+	flag.StringVar(&imageRegistryFlag, "test.image-registry", cmd.DefaultOptions.ImageRegistry, "image registry")
 	flag.StringVar(&flavorServiceRepositoryFlag, "test.flavor-service-repository", cmd.DefaultOptions.FlavorServiceRepository, "flavor service repository")
 	flag.StringVar(&installerExternalRepository, "test.installer-external-repository", cmd.DefaultOptions.InstallerExternalRepository, "image repository for the installer (external)")
 	flag.StringVar(&installerInternalRepository, "test.installer-internal-repository", cmd.DefaultOptions.InstallerInternalRepository, "image repository for the installer (internal)")

--- a/internal/integration/meta_test.go
+++ b/internal/integration/meta_test.go
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getVersions(ctx context.Context, t *testing.T, baseURL string) []string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/versions", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		resp.Body.Close()
+	})
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var versions []string
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&versions))
+
+	return versions
+}
+
+type extensionInfo struct {
+	Name   string `json:"name"`
+	Ref    string `json:"ref"`
+	Digest string `json:"digest"`
+}
+
+func getExtensions(ctx context.Context, t *testing.T, baseURL, talosVersion string) []extensionInfo {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/version/"+talosVersion+"/extensions/official", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		resp.Body.Close()
+	})
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var extensions []extensionInfo
+
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&extensions))
+
+	return extensions
+}
+
+func testMetaFrontend(ctx context.Context, t *testing.T, baseURL string) {
+	t.Run("versions", func(t *testing.T) {
+		t.Parallel()
+
+		versions := getVersions(ctx, t, baseURL)
+
+		assert.Greater(t, len(versions), 10)
+	})
+
+	t.Run("extensions", func(t *testing.T) {
+		t.Parallel()
+
+		talosVersions := []string{
+			"v1.5.0",
+			"v1.5.1",
+		}
+
+		for _, talosVersion := range talosVersions {
+			t.Run(talosVersion, func(t *testing.T) {
+				t.Parallel()
+
+				extensions := getExtensions(ctx, t, baseURL, talosVersion)
+
+				names := xslices.Map(extensions, func(ext extensionInfo) string {
+					return ext.Name
+				})
+
+				assert.Contains(t, names, "siderolabs/amd-ucode")
+				assert.Contains(t, names, "siderolabs/gvisor")
+				assert.Contains(t, names, "siderolabs/nvidia-open-gpu-kernel-modules")
+			})
+		}
+	})
+}

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -139,6 +139,7 @@ func testRegistryFrontend(ctx context.Context, t *testing.T, registryAddr string
 
 					for _, flavorID := range []string{
 						emptyFlavorID,
+						systemExtensionsFlavorID,
 						randomFlavorID,
 					} {
 						t.Run(flavorID, func(t *testing.T) {


### PR DESCRIPTION
Fixes #13

This builds on top of extensions catalog (see
https://github.com/siderolabs/extensions/pull/225), and existing support for specifying extension in the flavor.

Image Service resolve the list of extensions requested for a specific version of Talos into a list of container images, pulls them, and attaches them to the image request.

Image Service also provides endpoints to get information about available Talos versions, supported extensions for each version, etc.

I also refactored a bit flow around fetching & verifying image to re-use it in other flows, added support for authentication to the registry.